### PR TITLE
add buffer functionality as paramater in track_bower_circling in bower_circling.py

### DIFF
--- a/behavior_detection/BehavioralVideo.py
+++ b/behavior_detection/BehavioralVideo.py
@@ -146,7 +146,8 @@ class BehavioralVideo:
                              threshold=60,
                              track_age=18,
                              bower_circling_length=30,
-                             extract_clips=True):
+                             extract_clips=True,
+                             buffer = 0):
         """
         Checks to see if bower circling occurs in this clip
 
@@ -171,11 +172,16 @@ class BehavioralVideo:
             raise ValueError("Make sure to run calculate_velocities() or create_velocity_video() before attempting to "
                              "track bower circling.")
         bc.track_bower_circling(self.video, self.frames, proximity, head_tail_proximity, track_age, threshold,
-                                bower_circling_length, extract_clips)
+                                bower_circling_length, extract_clips, buffer)
 
     def set(self, **kwargs):
         """
         Sets any field. Use with caution to avoid unexpected behaviour
         """
-        self.video = kwargs['video_path']
-        self.tracklets_path = kwargs['tracklets_path']
+        for key in kwargs:
+            if key == 'video_path':
+                self.video = kwargs['video_path']
+            elif key == 'tracklets_path':
+                self.tracklets_path = kwargs['tracklets_path']
+            elif key == 'velocities':
+                self.frames = kwargs['velocities']

--- a/behavior_detection/bower_circling.py
+++ b/behavior_detection/bower_circling.py
@@ -19,7 +19,7 @@ np.seterr(divide='ignore', invalid='ignore')
 def track_bower_circling(video: str, frames: typing.Dict[typing.AnyStr, typing.Dict[typing.AnyStr, Fish]],
                          proximity: int,
                          head_tail_proximity: int, track_age: int, threshold: int, bower_circling_length: int,
-                         extract_clips: bool, debug=False):
+                         extract_clips: bool, buffer: int, debug=False):
     theta = math.radians(threshold)
     tracks = {}
     for frame_num, frame in tqdm(frames.items(), desc="Tracking bower circling incidents..."):
@@ -127,7 +127,7 @@ def track_bower_circling(video: str, frames: typing.Dict[typing.AnyStr, typing.D
     print(f"Added {len(bower_circling_incidents)} bower circling track(s) to frames data.")
 
     if extract_clips:
-        extract_incidents(bower_circling_incidents, video, behavior="bower-circling")
+        extract_incidents(bower_circling_incidents, video, buffer, behavior="bower-circling")
 
     return bower_circling_incidents
 

--- a/behavior_detection/misc/video_auxiliary.py
+++ b/behavior_detection/misc/video_auxiliary.py
@@ -192,7 +192,7 @@ def create_velocity_video(video_path: str, tracklets_path: str, velocities=None,
 
 
 # generalise this to work with any kind of behavior, not just bower circling
-def extract_incidents(bower_circling_incidents: list, video: str, behavior: str):
+def extract_incidents(bower_circling_incidents: list, video: str, buffer: int, behavior: str):
     if video is None or len(video) == 0 or not os.path.exists(video):
         raise TypeError("Video path cannot be empty.")
 
@@ -208,7 +208,7 @@ def extract_incidents(bower_circling_incidents: list, video: str, behavior: str)
         os.mkdir(output_dir)
     fps = get_video_fps(video)
     for incident in tqdm(bower_circling_incidents, f"Extracting {behavior} clips..."):
-        start_f, end_f = str_to_int(incident.start), str_to_int(incident.end)
+        start_f, end_f = str_to_int(incident.start) - (fps * buffer), str_to_int(incident.end) + (fps * buffer)
         start = str(timedelta(seconds=(start_f / fps)))
         abs_start = start if batch_num is None else str(timedelta(seconds=(start_f / fps) + 3600 * batch_num))
         end = str(timedelta(seconds=(end_f / fps)))


### PR DESCRIPTION
add buffer functionality as parameter in track_bower_circling in bower_circling.py.
- buffer adds x second long padding to start and beginning of clips
- example: if a 1 second long clip is classified as a bower circling clip, a 2s buffer would save the clip as: 2 second before clip video/1 s bower circling/2s after video clip